### PR TITLE
Add ContentTypeBase resource

### DIFF
--- a/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentTypeBaseDto.cs
+++ b/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentTypeBaseDto.cs
@@ -1,0 +1,9 @@
+﻿using Reinforced.Typings.Attributes;
+
+namespace EpiContentUsage.Api.Features.ContentTypeBase;
+
+[TsInterface]
+public class ContentTypeBaseDto
+{
+    public string Name { get; set; }
+}

--- a/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentTypeBaseDto.cs
+++ b/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentTypeBaseDto.cs
@@ -1,6 +1,6 @@
 ﻿using Reinforced.Typings.Attributes;
 
-namespace EpiContentUsage.Api.Features.ContentTypeBase;
+namespace Forte.EpiContentUsage.Api.Features.ContentTypeBase;
 
 [TsInterface]
 public class ContentTypeBaseDto

--- a/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentUsageController.cs
+++ b/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentUsageController.cs
@@ -1,0 +1,37 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using EpiContentUsage.Api.Services;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Swashbuckle.AspNetCore.Annotations;
+
+namespace EpiContentUsage.Api.Features.ContentTypeBase;
+
+[ApiController]
+[Authorize(Roles = "CmsAdmins")]
+[Route("[controller]")]
+public class ContentTypeBaseController : ControllerBase
+{
+    public const string GetContentTypeBasesRouteName = "ContentTypeBases";
+    
+    private readonly ContentTypeBaseService _contentTypeBaseService;
+    
+    public ContentTypeBaseController(ContentTypeBaseService contentTypeBaseService)
+    {
+        _contentTypeBaseService = contentTypeBaseService;
+    }
+
+    [HttpGet]
+    [SwaggerResponse(StatusCodes.Status200OK, null, typeof(IEnumerable<ContentTypeBaseDto>))]
+    [Route("[action]", Name = GetContentTypeBasesRouteName)]
+    public ActionResult GetContentTypeBases()
+    {
+        var contentTypeBases = _contentTypeBaseService.GetAll();
+
+        var contentTypeBaseDtos =
+            contentTypeBases.Select(contentTypeBase => new ContentTypeBaseDto { Name = contentTypeBase.ToString() });
+
+        return Ok(contentTypeBaseDtos);
+    }
+}

--- a/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentUsageController.cs
+++ b/src/EpiContentUsage/Api/Features/ContentTypeBase/ContentUsageController.cs
@@ -1,12 +1,12 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
-using EpiContentUsage.Api.Services;
+using Forte.EpiContentUsage.Api.Services;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using Swashbuckle.AspNetCore.Annotations;
 
-namespace EpiContentUsage.Api.Features.ContentTypeBase;
+namespace Forte.EpiContentUsage.Api.Features.ContentTypeBase;
 
 [ApiController]
 [Authorize(Roles = "CmsAdmins")]

--- a/src/EpiContentUsage/Api/Services/ContentTypeBaseService.cs
+++ b/src/EpiContentUsage/Api/Services/ContentTypeBaseService.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using EPiServer.Core;
+using EPiServer.DataAbstraction;
+using EPiServer.ServiceLocation;
+
+namespace EpiContentUsage.Api.Services;
+
+[ServiceConfiguration(Lifecycle = ServiceInstanceScope.Scoped)]
+public class ContentTypeBaseService
+{
+    private static readonly IDictionary<ContentTypeBase, Type> _contentTypeBases = new Dictionary<ContentTypeBase, Type>
+    {
+        {
+            ContentTypeBase.Page,
+            typeof(PageData)
+        },
+        {
+            ContentTypeBase.Block,
+            typeof(BlockData)
+        },
+        {
+            ContentTypeBase.Folder,
+            typeof(ContentFolder)
+        },
+        {
+            ContentTypeBase.Video,
+            typeof(VideoData)
+        },
+        {
+            ContentTypeBase.Image,
+            typeof(ImageData)
+        },
+        {
+            ContentTypeBase.Media,
+            typeof(MediaData)
+        }
+    };
+
+    public IEnumerable<ContentTypeBase> GetAll()
+    {
+        return _contentTypeBases.Keys;
+    }
+}

--- a/src/EpiContentUsage/Api/Services/ContentTypeBaseService.cs
+++ b/src/EpiContentUsage/Api/Services/ContentTypeBaseService.cs
@@ -4,7 +4,7 @@ using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.ServiceLocation;
 
-namespace EpiContentUsage.Api.Services;
+namespace Forte.EpiContentUsage.Api.Services;
 
 [ServiceConfiguration(Lifecycle = ServiceInstanceScope.Scoped)]
 public class ContentTypeBaseService

--- a/src/EpiContentUsage/Controllers/MainViewController.cs
+++ b/src/EpiContentUsage/Controllers/MainViewController.cs
@@ -1,4 +1,5 @@
 ﻿using EpiContentUsage.Api.Features.ContentType;
+using EpiContentUsage.Api.Features.ContentTypeBase;
 using EpiContentUsage.Api.Features.ContentUsage;
 using EpiContentUsage.ViewModels;
 using EPiServer.Shell.Modules;
@@ -22,6 +23,7 @@ public class MainViewController : Controller
 
         var viewModel = new MainViewViewModel(
             moduleBaseUrl,
+            Url.RouteUrl(ContentTypeBaseController.GetContentTypeBasesRouteName),
             Url.RouteUrl(ContentTypeController.GetContentTypesRouteName),
             Url.RouteUrl(ContentUsageController.GetContentUsagesRouteName)
         );

--- a/src/EpiContentUsage/Frontend/App.tsx
+++ b/src/EpiContentUsage/Frontend/App.tsx
@@ -11,6 +11,7 @@ export const App = ({model}: AppProps) => (
     <Workspace>
         <Card>
             <h1>{model.moduleBaseUrl}</h1>
+            <TextButton href={model.contentTypeBasesEndpointUrl}>Content Type Bases Endpoint</TextButton>
             <TextButton href={model.contentTypesEndpointUrl}>Content Types Endpoint</TextButton>
             <TextButton href={model.contentUsagesEndpointUrl}>Content Usages Endpoint</TextButton>
         </Card>

--- a/src/EpiContentUsage/Reinforced.Typings.settings.xml
+++ b/src/EpiContentUsage/Reinforced.Typings.settings.xml
@@ -34,7 +34,7 @@
             in attributes and in fluent methods then configuration from fluent methods will
             be used.
         -->
-        <RtConfigurationMethod>EpiContentUsage.ReinforcedTypingsConfiguration.Configure</RtConfigurationMethod>
+        <RtConfigurationMethod>Forte.EpiContentUsage.ReinforcedTypingsConfiguration.Configure</RtConfigurationMethod>
 
         <!--
             By default all of your typings will be located in single file specified by RtTargetFile.

--- a/src/EpiContentUsage/ViewModels/MainViewViewModel.cs
+++ b/src/EpiContentUsage/ViewModels/MainViewViewModel.cs
@@ -4,7 +4,7 @@ namespace Forte.EpiContentUsage.ViewModels;
 
 public class MainViewViewModel
 {
-    public MainViewViewModel(string moduleBaseUrl, string contentTypeBasesEndpointUrl,  string contentTypeEndpointUrl,
+    public MainViewViewModel(string moduleBaseUrl, string contentTypeBasesEndpointUrl, string contentTypeEndpointUrl,
         string contentTypesEndpointUrl, string contentUsagesEndpointUrl) =>
         FrontendAppModel =
             new AppModel

--- a/src/EpiContentUsage/ViewModels/MainViewViewModel.cs
+++ b/src/EpiContentUsage/ViewModels/MainViewViewModel.cs
@@ -4,11 +4,12 @@ namespace EpiContentUsage.ViewModels;
 
 public class MainViewViewModel
 {
-    public MainViewViewModel(string moduleBaseUrl, string contentTypesEndpointUrl, string contentUsagesEndpointUrl) =>
+    public MainViewViewModel(string moduleBaseUrl, string contentTypeBasesEndpointUrl, string contentTypesEndpointUrl, string contentUsagesEndpointUrl) =>
         FrontendAppModel =
             new AppModel
             {
                 ModuleBaseUrl = moduleBaseUrl,
+                ContentTypeBasesEndpointUrl = contentTypeBasesEndpointUrl,
                 ContentTypesEndpointUrl = contentTypesEndpointUrl,
                 ContentUsagesEndpointUrl = contentUsagesEndpointUrl
             };
@@ -20,6 +21,7 @@ public class MainViewViewModel
 public class AppModel
 {
     public string ModuleBaseUrl { get; set; }
+    public string ContentTypeBasesEndpointUrl { get; set; }
     public string ContentTypesEndpointUrl { get; set; }
     public string ContentUsagesEndpointUrl { get; set; }
 }


### PR DESCRIPTION
Adds `/ContentTypeBase/GetContentTypeBases` endpoint that lists all possible values that can be passed  to `/ContentType/GetContentTypes?type=`**[here]**.

Therefore we can create a new filter in the Content Types view with a dropdown input.