### PR TITLE
Add default favicon (taken from default EpiServer admin panel path)

### DIFF
--- a/src/EpiContentUsage/Forte.EpiContentUsage.Views/Views/Shared/_ShellLayout.cshtml
+++ b/src/EpiContentUsage/Forte.EpiContentUsage.Views/Views/Shared/_ShellLayout.cshtml
@@ -10,7 +10,7 @@
 <html lang="en">
     <head>
         <title>Optimizely Content Usage</title>
-
+        <link rel="shortcut icon" href="/Util/images/favicon.ico" type="image/x-icon">
         <!-- Shell -->
         @ClientResources.RenderResources("ShellCore")
 

--- a/src/EpiContentUsage/Forte.EpiContentUsage.Views/Views/Shared/_ShellLayout.cshtml
+++ b/src/EpiContentUsage/Forte.EpiContentUsage.Views/Views/Shared/_ShellLayout.cshtml
@@ -10,6 +10,10 @@
 <html lang="en">
     <head>
         <title>Optimizely Content Usage</title>
+        
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=Edge">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <link rel="shortcut icon" href="/Util/images/favicon.ico" type="image/x-icon">
         <!-- Shell -->
         @ClientResources.RenderResources("ShellCore")


### PR DESCRIPTION
This PR fixes #34.

It uses default EpiServer path for CMS panel's favicon ("Util/images/favicon.ico") which is delivered by Epi package 