### PR TITLE
Fix content versioning and unpublished content issues

### DIFF
--- a/src/EpiContentUsage/Api/Features/ContentType/ContentTypeMapper.cs
+++ b/src/EpiContentUsage/Api/Features/ContentType/ContentTypeMapper.cs
@@ -1,14 +1,15 @@
-﻿using EPiServer.Core;
+﻿using System.Linq;
+using Forte.EpiContentUsage.Api.Services;
 
 namespace Forte.EpiContentUsage.Api.Features.ContentType;
 
 public class ContentTypeMapper
 {
-    private readonly IContentModelUsage _contentModelUsage;
-
-    public ContentTypeMapper(IContentModelUsage contentModelUsage)
+    private readonly ContentUsageService _contentUsageService;
+    
+    public ContentTypeMapper(ContentUsageService contentUsageService)
     {
-        _contentModelUsage = contentModelUsage;
+        _contentUsageService = contentUsageService;
     }
 
     public ContentTypeDto Map(EPiServer.DataAbstraction.ContentType contentType)
@@ -19,7 +20,7 @@ public class ContentTypeMapper
             Name = contentType.Name,
             Guid = contentType.GUID,
             Type = contentType.Base.ToString(),
-            UsageCount = _contentModelUsage.ListContentOfContentType(contentType).Count
+            UsageCount = _contentUsageService.GetContentUsages(contentType).Count()
         };
 
         return dto;

--- a/src/EpiContentUsage/Api/Features/ContentUsage/ContentUsageController.cs
+++ b/src/EpiContentUsage/Api/Features/ContentUsage/ContentUsageController.cs
@@ -45,7 +45,7 @@ public class ContentUsageController : ControllerBase
             ContentTypeGuid = guid,
             Name = contentUsage.Name,
             LanguageBranch = contentUsage.LanguageBranch,
-            PageUrls = _contentUsageService.GetPageUrls(contentUsage.ContentLink),
+            PageUrls = _contentUsageService.GetPageUrls(contentUsage),
             EditUrl = _contentUsageService.GetEditUrl(contentUsage)
         });
 

--- a/src/EpiContentUsage/Api/Features/ContentUsage/ContentUsageController.cs
+++ b/src/EpiContentUsage/Api/Features/ContentUsage/ContentUsageController.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using Forte.EpiContentUsage.Api.Services;
 using Microsoft.AspNetCore.Authorization;
@@ -19,15 +18,12 @@ public class ContentUsageController : ControllerBase
 {
     public const string GetContentUsagesRouteName = "ContentUsages";
 
-    private readonly IContentModelUsage _contentModelUsage;
     private readonly IContentTypeRepository _contentTypeRepository;
     private readonly ContentUsageService _contentUsageService;
 
-    public ContentUsageController(IContentTypeRepository contentTypeRepository, IContentModelUsage contentModelUsage,
-        ContentUsageService contentUsageService)
+    public ContentUsageController(IContentTypeRepository contentTypeRepository, ContentUsageService contentUsageService)
     {
         _contentTypeRepository = contentTypeRepository;
-        _contentModelUsage = contentModelUsage;
         _contentUsageService = contentUsageService;
     }
 
@@ -39,12 +35,9 @@ public class ContentUsageController : ControllerBase
     {
         var contentType = _contentTypeRepository.Load(guid);
 
-        if (contentType == null)
-        {
-            return NotFound();
-        }
-        
-        var contentUsages = _contentModelUsage.ListContentOfContentType(contentType);
+        if (contentType == null) return NotFound();
+
+        var contentUsages = _contentUsageService.GetContentUsages(contentType);
 
         var contentUsagesDto = contentUsages.Select(contentUsage => new ContentUsageDto
         {

--- a/src/EpiContentUsage/Api/Services/ContentUsageService.cs
+++ b/src/EpiContentUsage/Api/Services/ContentUsageService.cs
@@ -4,21 +4,21 @@ using EPiServer;
 using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.Editor;
-using EPiServer.Filters;
 using EPiServer.Web.Routing;
 
 namespace Forte.EpiContentUsage.Api.Services;
 
 public class ContentUsageService
 {
-    private readonly IContentModelUsage _contentModelUsage;
     private readonly IContentLoader _contentLoader;
-    private readonly IPublishedStateAssessor _publishedStateAssessor;
+    private readonly IContentModelUsage _contentModelUsage;
     private readonly IContentSoftLinkRepository _contentSoftLinkRepository;
+    private readonly IPublishedStateAssessor _publishedStateAssessor;
     private readonly IUrlResolver _urlResolver;
 
     public ContentUsageService(IUrlResolver urlResolver, IContentSoftLinkRepository contentSoftLinkRepository,
-        IContentModelUsage contentModelUsage, IContentLoader contentLoader, IPublishedStateAssessor publishedStateAssessor)
+        IContentModelUsage contentModelUsage, IContentLoader contentLoader,
+        IPublishedStateAssessor publishedStateAssessor)
     {
         _urlResolver = urlResolver;
         _contentSoftLinkRepository = contentSoftLinkRepository;
@@ -31,16 +31,14 @@ public class ContentUsageService
     {
         var url = _urlResolver.GetUrl(contentLink);
 
-        if (!string.IsNullOrEmpty(url))
-        {
+        if (!string.IsNullOrEmpty(url)) 
             return CheckIsPublished(contentLink) ? new[] { url } : new string[] { };
-        }
-        
+
         var pageLinks = _contentSoftLinkRepository.Load(contentLink, true)
             .Where(softLink => softLink.SoftLinkType == ReferenceType.PageLinkReference)
             .Select(softLink => softLink.OwnerContentLink)
             .Where(ownerContentLink => ownerContentLink != null && CheckIsPublished(ownerContentLink));
-        
+
         return pageLinks.Select(pageLink => _urlResolver.GetUrl(pageLink));
     }
 
@@ -64,7 +62,7 @@ public class ContentUsageService
     private bool CheckIsPublished(ContentReference contentLink)
     {
         var content = _contentLoader.Get<IContent>(contentLink);
-        
+
         return _publishedStateAssessor.IsPublished(content);
     }
 }

--- a/src/EpiContentUsage/Api/Services/ContentUsageService.cs
+++ b/src/EpiContentUsage/Api/Services/ContentUsageService.cs
@@ -27,9 +27,10 @@ public class ContentUsageService
         _publishedStateAssessor = publishedStateAssessor;
     }
 
-    public IEnumerable<string> GetPageUrls(ContentReference contentLink)
+    public IEnumerable<string> GetPageUrls(ContentUsage contentUsage)
     {
-        var url = _urlResolver.GetUrl(contentLink);
+        var contentLink = contentUsage.ContentLink;
+        var url = _urlResolver.GetUrl(contentLink, contentUsage.LanguageBranch);
 
         if (!string.IsNullOrEmpty(url)) 
             return CheckIsPublished(contentLink) ? new[] { url } : new string[] { };
@@ -39,14 +40,14 @@ public class ContentUsageService
             .Select(softLink => softLink.OwnerContentLink)
             .Where(ownerContentLink => ownerContentLink != null && CheckIsPublished(ownerContentLink));
 
-        return pageLinks.Select(pageLink => _urlResolver.GetUrl(pageLink));
+        return pageLinks.Select(pageLink => _urlResolver.GetUrl(pageLink, contentUsage.LanguageBranch));
     }
 
     public string GetEditUrl(ContentUsage contentUsage)
     {
         var latestVersionContentLink = contentUsage.ContentLink.ToReferenceWithoutVersion();
 
-        return PageEditing.GetEditUrl(latestVersionContentLink);
+        return PageEditing.GetEditUrlForLanguage(latestVersionContentLink, contentUsage.LanguageBranch);
     }
 
     public IEnumerable<ContentUsage> GetContentUsages(ContentType contentType)

--- a/src/EpiContentUsage/Api/Services/ContentUsageService.cs
+++ b/src/EpiContentUsage/Api/Services/ContentUsageService.cs
@@ -1,8 +1,10 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using EPiServer;
 using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.Editor;
+using EPiServer.Filters;
 using EPiServer.Web.Routing;
 
 namespace Forte.EpiContentUsage.Api.Services;
@@ -10,29 +12,36 @@ namespace Forte.EpiContentUsage.Api.Services;
 public class ContentUsageService
 {
     private readonly IContentModelUsage _contentModelUsage;
+    private readonly IContentLoader _contentLoader;
+    private readonly IPublishedStateAssessor _publishedStateAssessor;
     private readonly IContentSoftLinkRepository _contentSoftLinkRepository;
     private readonly IUrlResolver _urlResolver;
 
     public ContentUsageService(IUrlResolver urlResolver, IContentSoftLinkRepository contentSoftLinkRepository,
-        IContentModelUsage contentModelUsage)
+        IContentModelUsage contentModelUsage, IContentLoader contentLoader, IPublishedStateAssessor publishedStateAssessor)
     {
         _urlResolver = urlResolver;
         _contentSoftLinkRepository = contentSoftLinkRepository;
         _contentModelUsage = contentModelUsage;
+        _contentLoader = contentLoader;
+        _publishedStateAssessor = publishedStateAssessor;
     }
 
     public IEnumerable<string> GetPageUrls(ContentReference contentLink)
     {
         var url = _urlResolver.GetUrl(contentLink);
 
-        if (!string.IsNullOrEmpty(url)) return new[] { url };
-
-        var urls = _contentSoftLinkRepository.Load(contentLink, true)
-            .Where(softLink => softLink.SoftLinkType == ReferenceType.PageLinkReference &&
-                               !ContentReference.IsNullOrEmpty(softLink.OwnerContentLink))
-            .Select(softLink => _urlResolver.GetUrl(softLink.OwnerContentLink));
-
-        return urls;
+        if (!string.IsNullOrEmpty(url))
+        {
+            return CheckIsPublished(contentLink) ? new[] { url } : new string[] { };
+        }
+        
+        var pageLinks = _contentSoftLinkRepository.Load(contentLink, true)
+            .Where(softLink => softLink.SoftLinkType == ReferenceType.PageLinkReference)
+            .Select(softLink => softLink.OwnerContentLink)
+            .Where(ownerContentLink => ownerContentLink != null && CheckIsPublished(ownerContentLink));
+        
+        return pageLinks.Select(pageLink => _urlResolver.GetUrl(pageLink));
     }
 
     public string GetEditUrl(ContentUsage contentUsage)
@@ -50,5 +59,12 @@ public class ContentUsageService
             .Select(v => v.MaxBy(u => u.ContentLink.WorkID));
 
         return contentUsageLatestVersions;
+    }
+
+    private bool CheckIsPublished(ContentReference contentLink)
+    {
+        var content = _contentLoader.Get<IContent>(contentLink);
+        
+        return _publishedStateAssessor.IsPublished(content);
     }
 }


### PR DESCRIPTION
Closes #32 
Closes #33 
Closes #20 

This PR should fix the issues that happened when a content (block or page) is:
- not published yet, therefore it is pointless to return an invalid url to unpublished content
- already published more than once because of any editorial changes - then we have to ensure that we only list the latest published  content version and that edit url links to the latest content version as well

 
